### PR TITLE
Add IgnoreUnmatchedProperties to deserializer configuration

### DIFF
--- a/src/ProjectOrigin.ServiceCommon/UriOptionsLoader/ConfigureExtensions.cs
+++ b/src/ProjectOrigin.ServiceCommon/UriOptionsLoader/ConfigureExtensions.cs
@@ -42,6 +42,7 @@ public static class ConfigureExtensions
         services.AddSingleton<IDeserializer>(
             deserializerBuilderConfigure(new DeserializerBuilder()
             .WithNamingConvention(CamelCaseNamingConvention.Instance))
+            .IgnoreUnmatchedProperties()
             .Build());
 
         services.AddSingleton<IOptionsValidator<TOption>, OptionsValidator<TOption>>();

--- a/test/ProjectOrigin.ServiceCommon.Tests/UriOptionsLoaderTests.cs
+++ b/test/ProjectOrigin.ServiceCommon.Tests/UriOptionsLoaderTests.cs
@@ -254,6 +254,7 @@ public class UriOptionsLoaderTests
                     someKey: "bla1"
                   key2:
                     someKey: "bla2"
+                someUnknownKey: "bla3"
                 """;
 
         var path = TempFile.WriteAllText(yaml, ".yaml");


### PR DESCRIPTION
Enhance the deserializer configuration by adding the `IgnoreUnmatchedProperties` option, allowing it to ignore unknown keys in the input data.