### PR TITLE
upgrade common library dependencies

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,9 +2,12 @@
 // README at: https://github.com/devcontainers/templates/tree/main/src/dotnet
 {
     "name": "C# (.NET)",
-    "image": "mcr.microsoft.com/devcontainers/dotnet:1.1.6-8.0-jammy",
+    "image": "mcr.microsoft.com/devcontainers/dotnet:1.3.6-9.0-noble",
     // Features to add to the dev container. More info: https://containers.dev/features.
     "features": {
+        "ghcr.io/devcontainers/features/dotnet:2" : {
+            "additionalVersions": "9.0.102"
+        },
         "ghcr.io/devcontainers/features/docker-in-docker:2": {}
     },
     // Use 'forwardPorts' to make a list of ports inside the container available locally.

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>disable</ImplicitUsings>
     <WarningsAsErrors>IDE0005</WarningsAsErrors>

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
     "sdk": {
-        "version": "8.0.203",
+        "version": "9.0.102",
         "rollForward": "feature"
     }
 }

--- a/src/ProjectOrigin.ServiceCommon/Database/DatabaseUpgrader.cs
+++ b/src/ProjectOrigin.ServiceCommon/Database/DatabaseUpgrader.cs
@@ -82,19 +82,22 @@ public class DatabaseUpgrader : IDatabaseUpgrader
             _logger = logger;
         }
 
-        public void WriteError(string format, params object[] args)
-        {
-            _logger.LogError(format, args);
-        }
+        public void LogTrace(string format, params object[] args) =>
+            _logger.LogTrace(format, args);
 
-        public void WriteInformation(string format, params object[] args)
-        {
+        public void LogDebug(string format, params object[] args) =>
+            _logger.LogDebug(format, args);
+
+        public void LogInformation(string format, params object[] args) =>
             _logger.LogInformation(format, args);
-        }
 
-        public void WriteWarning(string format, params object[] args)
-        {
+        public void LogWarning(string format, params object[] args) =>
             _logger.LogWarning(format, args);
-        }
+
+        public void LogError(string format, params object[] args) =>
+            _logger.LogError(format, args);
+
+        public void LogError(Exception ex, string format, params object[] args) =>
+            _logger.LogError(ex, format, args);
     }
 }

--- a/src/ProjectOrigin.ServiceCommon/ProjectOrigin.ServiceCommon.csproj
+++ b/src/ProjectOrigin.ServiceCommon/ProjectOrigin.ServiceCommon.csproj
@@ -11,24 +11,24 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Dapper" Version="2.1.35" />
-    <PackageReference Include="dbup-postgresql" Version="5.0.40" />
-    <PackageReference Include="Grpc.AspNetCore" Version="2.62.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Options.DataAnnotations" Version="8.0.0" />
-    <PackageReference Include="Npgsql" Version="8.0.3" />
-    <PackageReference Include="Npgsql.OpenTelemetry" Version="8.0.3" />
-    <PackageReference Include="OpenTelemetry" Version="1.8.1" />
-    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.8.0" />
-    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.8.1" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.8.1" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.GrpcNetClient" Version="1.8.0-beta.1" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.Process" Version="0.5.0-beta.5" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.8.1" />
-    <PackageReference Include="Serilog.AspNetCore" Version="8.0.1" />
+    <PackageReference Include="Dapper" Version="2.1.66" />
+    <PackageReference Include="dbup-postgresql" Version="6.0.3" />
+    <PackageReference Include="Grpc.AspNetCore" Version="2.67.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="9.0.2" />
+    <PackageReference Include="Microsoft.Extensions.Options.DataAnnotations" Version="9.0.2" />
+    <PackageReference Include="Npgsql" Version="9.0.3" />
+    <PackageReference Include="Npgsql.OpenTelemetry" Version="9.0.3" />
+    <PackageReference Include="OpenTelemetry" Version="1.11.2" />
+    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.11.2" />
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.11.2" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.11.0" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.GrpcNetClient" Version="1.11.0-beta.1" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Process" Version="1.11.0-beta.1" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.11.0" />
+    <PackageReference Include="Serilog.AspNetCore" Version="9.0.0" />
     <PackageReference Include="Serilog.Enrichers.Span" Version="3.1.0" />
-    <PackageReference Include="Serilog.Expressions" Version="4.0.0" />
-    <PackageReference Include="YamlDotNet" Version="16.0.0" />
+    <PackageReference Include="Serilog.Expressions" Version="5.0.0" />
+    <PackageReference Include="YamlDotNet" Version="16.3.0" />
   </ItemGroup>
 
 </Project>

--- a/src/ProjectOrigin.TestCommon/ProjectOrigin.TestCommon.csproj
+++ b/src/ProjectOrigin.TestCommon/ProjectOrigin.TestCommon.csproj
@@ -15,13 +15,13 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Moq" Version="4.20.70" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
-    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="8.0.3" />
-    <PackageReference Include="xunit" Version="2.7.1" />
-    <PackageReference Include="Testcontainers.PostgreSql" Version="3.10.0" />
-    <PackageReference Include="Testcontainers.Redis" Version="3.10.0" />
-    <PackageReference Include="Testcontainers.RabbitMq" Version="3.10.0" />
+    <PackageReference Include="Moq" Version="4.20.72" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
+    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="9.0.2" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="Testcontainers.PostgreSql" Version="4.3.0" />
+    <PackageReference Include="Testcontainers.Redis" Version="4.3.0" />
+    <PackageReference Include="Testcontainers.RabbitMq" Version="4.3.0" />
   </ItemGroup>
 
 </Project>

--- a/test/ProjectOrigin.ServiceCommon.Tests/ProjectOrigin.ServiceCommon.Tests.csproj
+++ b/test/ProjectOrigin.ServiceCommon.Tests/ProjectOrigin.ServiceCommon.Tests.csproj
@@ -7,18 +7,18 @@
 
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="6.12.0" />
-    <PackageReference Include="Moq" Version="4.20.70" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
-    <PackageReference Include="xunit" Version="2.7.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.8">
+    <PackageReference Include="Moq" Version="4.20.72" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.2">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="6.0.2">
+    <PackageReference Include="coverlet.collector" Version="6.0.4">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="1.5.52" />
+    <PackageReference Include="WireMock.Net" Version="1.7.4" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
This will be released as a v.2.0.0, indicating a breaking change, as dotnet 9 will be needed to use this package from now on.